### PR TITLE
Add support for MS-SQL TIME data type

### DIFF
--- a/DataMgr_MSSQL.cfc
+++ b/DataMgr_MSSQL.cfc
@@ -409,6 +409,7 @@
 		<cfcase value="smallint"><cfset result = "CF_SQL_SMALLINT"></cfcase>
 		<cfcase value="smallmoney"><cfset result = "CF_SQL_MONEY4"></cfcase>
 		<cfcase value="text"><cfset result = "CF_SQL_LONGVARCHAR"></cfcase>
+		<cfcase value="time"><cfset result = "CF_SQL_TIME"></cfcase>
 		<cfcase value="tinyint"><cfset result = "CF_SQL_TINYINT"></cfcase>
 		<cfcase value="uniqueidentifier"><cfset result = "CF_SQL_IDSTAMP"></cfcase>
 		<cfcase value="varchar">
@@ -454,6 +455,7 @@
 		<cfcase value="CF_SQL_NUMERIC"><cfset result = "numeric"></cfcase>
 		<cfcase value="CF_SQL_REAL"><cfset result = "real"></cfcase>
 		<cfcase value="CF_SQL_SMALLINT"><cfset result = "smallint"></cfcase>
+		<cfcase value="CF_SQL_TIME"><cfset result = "time"></cfcase>
 		<cfcase value="CF_SQL_TIMESTAMP"><cfset result = "datetime"></cfcase>
 		<cfcase value="CF_SQL_TINYINT"><cfset result = "tinyint"></cfcase>
 		<cfcase value="CF_SQL_VARCHAR"><cfset result = "varchar"></cfcase>

--- a/_DataMgr.cfc
+++ b/_DataMgr.cfc
@@ -5238,6 +5238,9 @@
 	<cfcase value="CF_SQL_DATETIME,CF_SQL_TIMESTAMP">
 		<cfset result = "datetime">
 	</cfcase>
+	<cfcase value="CF_SQL_TIME">
+		<cfset result = "time">
+	</cfcase>
 	<cfcase value="CF_SQL_LONGVARCHAR,CF_SQL_CLOB">
 		<cfset result = "invalid">
 	</cfcase>
@@ -5602,6 +5605,9 @@
 	<cfcase value="CF_SQL_DATE,CF_SQL_DATETIME">
 		<cfset result = "date">
 	</cfcase>
+	<cfcase value="CF_SQL_TIME">
+		<cfset result = "time">
+	</cfcase>
 	<cfdefaultcase>
 		<cfset result = arguments.CF_DataType>
 	</cfdefaultcase>
@@ -5640,6 +5646,9 @@
 	</cfcase>
 	<cfcase value="date">
 		<cfset isOK = isValidDate(datum)>
+	</cfcase>
+	<cfcase value="time">
+		<cfset isOK = isValid("time", datum)>
 	</cfcase>
 	<cfdefaultcase>
 		<cfset isOK = true>


### PR DESCRIPTION
Initial work to get DataMgr support for MS-SQL TIME data type.  
There may be some additional work needed, but this seems to get it working for now.

On Lucee, "sendTimeAsDateTime=false" needs to be added to the connection string of the ODBC driver.  This is probably needed on CF as well. 