### PR TITLE
Reduce spaces to make word filters more effective

### DIFF
--- a/SpamFilter.cfc
+++ b/SpamFilter.cfc
@@ -356,6 +356,8 @@
 	<cfargument name="string" type="string" require="true">
 	<cfargument name="word" type="string" require="true">
 	<cfargument name="maxpoints" type="numeric" default="0">
+	
+	<cfset arguments.string = javacast("string", arguments.string).replaceAll("\s+", " ")>
 
 	<cfreturn numRegExMatches(arguments.string,"\b#arguments.word#\b",arguments.maxpoints)>
 </cffunction>


### PR DESCRIPTION
Reduce multiple spaces\tabs\carriage returns to a single space to make word filters easier.

This sanitization filter makes it possible to write a single rule to handle situations where multiple rules would otherwise be needed due to randomized spacing.

This content:
```
To unsubscribe,
click here
```
... is sanitized to `To unsubscribe, click here` so that a single rule works regardless of the amount of space class characters added between non-space characters.